### PR TITLE
Add default value for static filters

### DIFF
--- a/static-filter-list.json
+++ b/static-filter-list.json
@@ -3,14 +3,17 @@
         "geos": {
             "default": 0,
             "US": 1
-        },
+        }
+    },{
         "formats": {
             "default": 1
-        },
+        }
+    }, {
         "channels": {
             "web": 1,
             "default": 0
-        },
+        }
+    }, {
         "domains": {
             "minehut.com": 1,
             "mmanews.com": 1,

--- a/static-filter-list.json
+++ b/static-filter-list.json
@@ -4,7 +4,9 @@
             "default": 0,
             "US": 1
         },
-        "formats": {},
+        "formats": {
+            "default": 1
+        },
         "channels": {
             "web": 1,
             "default": 0
@@ -936,9 +938,15 @@
         }
     }],
     "adobe": [{
-        "geos": {},
-        "formats": {},
-        "channels": {},
+        "geos": {
+            "default": 1
+        },
+        "formats": {
+            "default": 1
+        },
+        "channels": {
+            "default": 1
+        },
         "domains": {
             "acidigital.com": 1,
             "0x50.org": 1,
@@ -1198,8 +1206,14 @@
             "ID": 0,
             "NZ": 0
         },
-        "formats": {},
-        "channels": {},
-        "domains": {}
+        "formats": {
+            "default": 1
+        },
+        "channels": {
+            "default": 1
+        },
+        "domains": {
+            "default": 1
+        }
     }]
 }


### PR DESCRIPTION
If we have empty dimensions PBS will block all requests. We need to explicitly include everything.
Update ttdfsx filters to have separate segments to work as expected with PBS code changes.