### PR TITLE
S2S-1318 - Refactor the Dynamic Filters Cloud Function and Update Query

### DIFF
--- a/dynamicfilter/__init__.py
+++ b/dynamicfilter/__init__.py
@@ -1,0 +1,3 @@
+from .dynamicfilter import *
+
+__all__ = dynamicfilter.__all__

--- a/dynamicfilter/dynamicfilter.py
+++ b/dynamicfilter/dynamicfilter.py
@@ -1,0 +1,106 @@
+__all__ = ['map_query_results']
+
+DEFAULT = "default"
+
+
+def map_query_results(query_results):
+    final_json = {}
+
+    if len(query_results) == 0:
+        raise Exception("Failed to map results: empty query result list")
+
+    for row in query_results:
+
+        _check_row_format(row)
+
+        if _is_bidder_empty(final_json, row):
+            if _is_continent_default_row(row):
+                final_json = _build_bidder_continent_default(row)
+            else:
+                final_json |= _build_bidder_continent(row)
+        elif _is_continent_default_row(row):
+            final_json[row.Bidder][row.Continent] |= _build_continent_default(row)
+        elif _is_continent_empty(final_json, row):
+            final_json[row.Bidder] |= _build_continent(row)
+        elif _is_country_empty(final_json, row):
+            final_json[row.Bidder][row.Continent] |= _build_country(row)
+        else:
+            final_json[row.Bidder][row.Continent][row.Country] |= _update_country_host(row)
+
+    return final_json
+
+
+def _is_continent_empty(final_json, row):
+    return final_json.get(row.Bidder).get(row.Continent) is None
+
+
+def _is_bidder_empty(final_json, row):
+    return final_json.get(row.Bidder) is None
+
+
+def _check_row_format(row):
+    if not row.Bidder or not row.Continent or not row.Country or not row.Filter:
+        raise Exception("Invalid row format: empty column value is now allowed")
+    if _is_continent_default_row(row) and row.Host != DEFAULT:
+        raise Exception("Invalid row format: default country and non default host isn't allowed: {0}".format(row.Host))
+
+
+def _is_continent_default_row(row):
+    return row.Country == DEFAULT
+
+
+def _is_country_empty(final_json, row):
+    return final_json.get(row.Bidder).get(row.Continent).get(row.Country) is None
+
+
+def _update_country_host(row):
+    return {
+        row.Host: row.Filter
+    }
+
+
+def _build_country(row):
+    return {
+        row.Country: {
+            row.Host: row.Filter
+        }
+    }
+
+
+def _build_continent_default(row):
+    return {
+        DEFAULT: row.Filter
+    }
+
+
+def _build_continent(row):
+    return {
+        row.Continent: {
+            row.Country: {
+                row.Host: row.Filter
+            }
+        }
+    }
+
+
+def _build_bidder_continent_default(row):
+    return {
+        row.Bidder: {
+            row.Continent: {
+                DEFAULT: row.Filter
+            }
+        }
+
+    }
+
+
+def _build_bidder_continent(row):
+    return {
+        row.Bidder: {
+            row.Continent: {
+                row.Country: {
+                    row.Host: row.Filter
+                }
+            }
+        }
+    }

--- a/dynamicfilter/dynamicfilter.py
+++ b/dynamicfilter/dynamicfilter.py
@@ -58,21 +58,21 @@ def _is_country_empty(final_json, row):
 
 def _update_country_host(row):
     return {
-        row.host: row.filter
+        row.host: float(row.filter)
     }
 
 
 def _build_country(row):
     return {
         row.country: {
-            row.host: row.filter
+            row.host: float(row.filter)
         }
     }
 
 
 def _build_continent_default(row):
     return {
-        DEFAULT: row.filter
+        DEFAULT: float(row.filter)
     }
 
 
@@ -80,7 +80,7 @@ def _build_continent(row):
     return {
         row.continent: {
             row.country: {
-                row.host: row.filter
+                row.host: float(row.filter)
             }
         }
     }
@@ -89,7 +89,7 @@ def _build_continent(row):
 def _build_continent_2(row):
     return {
         row.continent: {
-            DEFAULT: row.filter
+            DEFAULT: float(row.filter)
         }
     }
 
@@ -98,7 +98,7 @@ def _build_bidder_continent_default(row):
     return {
         row.bidder: {
             row.continent: {
-                DEFAULT: row.filter
+                DEFAULT: float(row.filter)
             }
         }
     }
@@ -109,7 +109,7 @@ def _build_bidder_continent(row):
         row.bidder: {
             row.continent: {
                 row.country: {
-                    row.host: row.filter
+                    row.host: float(row.filter)
                 }
             }
         }

--- a/dynamicfilter/dynamicfilter.py
+++ b/dynamicfilter/dynamicfilter.py
@@ -6,9 +6,6 @@ DEFAULT = "default"
 def map_query_results(query_results):
     final_json = {}
 
-    if len(query_results) == 0:
-        raise Exception("Failed to map results: empty query result list")
-
     for row in query_results:
 
         _check_row_format(row)
@@ -18,88 +15,101 @@ def map_query_results(query_results):
                 final_json = _build_bidder_continent_default(row)
             else:
                 final_json |= _build_bidder_continent(row)
-        elif _is_continent_default_row(row):
-            final_json[row.Bidder][row.Continent] |= _build_continent_default(row)
         elif _is_continent_empty(final_json, row):
-            final_json[row.Bidder] |= _build_continent(row)
+            if _is_continent_default_row(row):
+                final_json[row.bidder] |= _build_continent_2(row)
+            else:
+                final_json[row.bidder] |= _build_continent(row)
+        elif _is_continent_default_row(row):
+            final_json[row.bidder][row.continent] |= _build_continent_default(row)
         elif _is_country_empty(final_json, row):
-            final_json[row.Bidder][row.Continent] |= _build_country(row)
+            final_json[row.bidder][row.continent] |= _build_country(row)
         else:
-            final_json[row.Bidder][row.Continent][row.Country] |= _update_country_host(row)
+            final_json[row.bidder][row.continent][row.country] |= _update_country_host(row)
+
+    if len(final_json) == 0:
+        raise Exception("Failed to map results: empty query result list")
 
     return final_json
 
 
 def _is_continent_empty(final_json, row):
-    return final_json.get(row.Bidder).get(row.Continent) is None
+    return final_json.get(row.bidder).get(row.continent) is None
 
 
 def _is_bidder_empty(final_json, row):
-    return final_json.get(row.Bidder) is None
+    return final_json.get(row.bidder) is None
 
 
 def _check_row_format(row):
-    if not row.Bidder or not row.Continent or not row.Country or not row.Filter:
-        raise Exception("Invalid row format: empty column value is now allowed")
-    if _is_continent_default_row(row) and row.Host != DEFAULT:
-        raise Exception("Invalid row format: default country and non default host isn't allowed: {0}".format(row.Host))
+    if not row.bidder or not row.continent or not row.country or row.filter is None or row.filter < 0:
+        raise Exception("Invalid row format: empty or negative column value is now allowed")
+    if _is_continent_default_row(row) and row.host != DEFAULT:
+        raise Exception("Invalid row format: default country and non default host isn't allowed: {0}".format(row.host))
 
 
 def _is_continent_default_row(row):
-    return row.Country == DEFAULT
+    return row.country == DEFAULT
 
 
 def _is_country_empty(final_json, row):
-    return final_json.get(row.Bidder).get(row.Continent).get(row.Country) is None
+    return final_json.get(row.bidder).get(row.continent).get(row.country) is None
 
 
 def _update_country_host(row):
     return {
-        row.Host: row.Filter
+        row.host: row.filter
     }
 
 
 def _build_country(row):
     return {
-        row.Country: {
-            row.Host: row.Filter
+        row.country: {
+            row.host: row.filter
         }
     }
 
 
 def _build_continent_default(row):
     return {
-        DEFAULT: row.Filter
+        DEFAULT: row.filter
     }
 
 
 def _build_continent(row):
     return {
-        row.Continent: {
-            row.Country: {
-                row.Host: row.Filter
+        row.continent: {
+            row.country: {
+                row.host: row.filter
             }
+        }
+    }
+
+
+def _build_continent_2(row):
+    return {
+        row.continent: {
+            DEFAULT: row.filter
         }
     }
 
 
 def _build_bidder_continent_default(row):
     return {
-        row.Bidder: {
-            row.Continent: {
-                DEFAULT: row.Filter
+        row.bidder: {
+            row.continent: {
+                DEFAULT: row.filter
             }
         }
-
     }
 
 
 def _build_bidder_continent(row):
     return {
-        row.Bidder: {
-            row.Continent: {
-                row.Country: {
-                    row.Host: row.Filter
+        row.bidder: {
+            row.continent: {
+                row.country: {
+                    row.host: row.filter
                 }
             }
         }

--- a/dynamicfilter/dynamicfilter.py
+++ b/dynamicfilter/dynamicfilter.py
@@ -10,22 +10,22 @@ def map_query_results(query_results):
 
         _check_row_format(row)
 
-        if _is_bidder_empty(final_json, row):
+        if _is_new_bidder(final_json, row.bidder):
             if _is_continent_default_row(row):
-                final_json = _build_bidder_continent_default(row)
+                final_json = _build_new_bidder_continent_default(row)
             else:
-                final_json |= _build_bidder_continent(row)
-        elif _is_continent_empty(final_json, row):
+                final_json |= _build_new_bidder_continent(row)
+        elif _is_new_bidder_continent(final_json, row.bidder, row.continent):
             if _is_continent_default_row(row):
-                final_json[row.bidder] |= _build_continent_2(row)
+                final_json[row.bidder] |= _build_new_continent_default(row)
             else:
-                final_json[row.bidder] |= _build_continent(row)
+                final_json[row.bidder] |= _build_new_continent(row)
         elif _is_continent_default_row(row):
-            final_json[row.bidder][row.continent] |= _build_continent_default(row)
-        elif _is_country_empty(final_json, row):
-            final_json[row.bidder][row.continent] |= _build_country(row)
+            final_json[row.bidder][row.continent] |= _build_default(row)
+        elif _is_new_country(final_json, row):
+            final_json[row.bidder][row.continent] |= _build_new_country(row)
         else:
-            final_json[row.bidder][row.continent][row.country] |= _update_country_host(row)
+            final_json[row.bidder][row.continent][row.country] |= _build_host(row)
 
     if len(final_json) == 0:
         raise Exception("Failed to map results: empty query result list")
@@ -33,12 +33,12 @@ def map_query_results(query_results):
     return final_json
 
 
-def _is_continent_empty(final_json, row):
-    return final_json.get(row.bidder).get(row.continent) is None
+def _is_new_bidder_continent(final_json, bidder, continent):
+    return final_json.get(bidder).get(continent) is None
 
 
-def _is_bidder_empty(final_json, row):
-    return final_json.get(row.bidder) is None
+def _is_new_bidder(final_json, bidder):
+    return final_json.get(bidder) is None
 
 
 def _check_row_format(row):
@@ -52,17 +52,17 @@ def _is_continent_default_row(row):
     return row.country == DEFAULT
 
 
-def _is_country_empty(final_json, row):
+def _is_new_country(final_json, row):
     return final_json.get(row.bidder).get(row.continent).get(row.country) is None
 
 
-def _update_country_host(row):
+def _build_host(row):
     return {
         row.host: float(row.filter)
     }
 
 
-def _build_country(row):
+def _build_new_country(row):
     return {
         row.country: {
             row.host: float(row.filter)
@@ -70,13 +70,13 @@ def _build_country(row):
     }
 
 
-def _build_continent_default(row):
+def _build_default(row):
     return {
         DEFAULT: float(row.filter)
     }
 
 
-def _build_continent(row):
+def _build_new_continent(row):
     return {
         row.continent: {
             row.country: {
@@ -86,7 +86,7 @@ def _build_continent(row):
     }
 
 
-def _build_continent_2(row):
+def _build_new_continent_default(row):
     return {
         row.continent: {
             DEFAULT: float(row.filter)
@@ -94,7 +94,7 @@ def _build_continent_2(row):
     }
 
 
-def _build_bidder_continent_default(row):
+def _build_new_bidder_continent_default(row):
     return {
         row.bidder: {
             row.continent: {
@@ -104,7 +104,7 @@ def _build_bidder_continent_default(row):
     }
 
 
-def _build_bidder_continent(row):
+def _build_new_bidder_continent(row):
     return {
         row.bidder: {
             row.continent: {

--- a/dynamicfilter/tests.py
+++ b/dynamicfilter/tests.py
@@ -196,30 +196,6 @@ class FunctionTestCase(unittest.TestCase):
         # then
         self.assertDictEqual(expected_default_continent, results)
 
-    def test_given_multiple_hosts_result_map_filters_correctly123(self):
-        # given
-        stub = [
-            DynamicFilterQueryResult('33across', 'AF', 'RU', 'default', 0.05),
-            DynamicFilterQueryResult('33across', 'AS', 'default', 'default', 0.05)
-        ]
-
-        expected_default_continent = {
-            "33across": {
-                "AF": {
-                    "default": 0.05
-                },
-                "AS": {
-                    "default": 0.05
-                }
-            }
-        }
-
-        # when
-        results = dynamicfilter.map_query_results(stub)
-
-        # then
-        self.assertDictEqual(expected_default_continent, results)
-
     def test_given_multiple_bidders_result_map_filters_correctly(self):
         # given
         stub = [

--- a/dynamicfilter/tests.py
+++ b/dynamicfilter/tests.py
@@ -1,6 +1,6 @@
 import unittest
 
-import function
+import dynamicfilter
 
 
 class FunctionTestCase(unittest.TestCase):
@@ -13,7 +13,7 @@ class FunctionTestCase(unittest.TestCase):
 
         # when-then
         with self.assertRaises(Exception) as e:
-            function.map_query_results(stub)
+            dynamicfilter.map_query_results(stub)
 
         self.assertTrue("Failed to map results: empty query result list" in str(e.exception))
 
@@ -25,7 +25,7 @@ class FunctionTestCase(unittest.TestCase):
 
         # when-then
         with self.assertRaises(Exception) as e:
-            print(function.map_query_results(stub))
+            print(dynamicfilter.map_query_results(stub))
 
         self.assertTrue("Invalid row format: default country and non default host isn't allowed: "
                         "www.testing.com" in str(e.exception))
@@ -38,7 +38,7 @@ class FunctionTestCase(unittest.TestCase):
 
         # when-then
         with self.assertRaises(Exception) as e:
-            print(function.map_query_results(stub))
+            print(dynamicfilter.map_query_results(stub))
 
         self.assertTrue("Invalid row format: empty column value is now allowed")
 
@@ -50,7 +50,7 @@ class FunctionTestCase(unittest.TestCase):
 
         # when-then
         with self.assertRaises(Exception) as e:
-            print(function.map_query_results(stub))
+            print(dynamicfilter.map_query_results(stub))
 
         self.assertTrue("Invalid row format: empty column value is now allowed")
 
@@ -73,7 +73,7 @@ class FunctionTestCase(unittest.TestCase):
         }
 
         # when
-        results = function.map_query_results(stub)
+        results = dynamicfilter.map_query_results(stub)
 
         # then
         self.assertDictEqual(expected_default_continent, results)
@@ -93,7 +93,7 @@ class FunctionTestCase(unittest.TestCase):
         }
 
         # when
-        results = function.map_query_results(stub)
+        results = dynamicfilter.map_query_results(stub)
 
         # then
         self.assertDictEqual(expected_default_continent, results)
@@ -115,7 +115,7 @@ class FunctionTestCase(unittest.TestCase):
         }
 
         # when
-        results = function.map_query_results(stub)
+        results = dynamicfilter.map_query_results(stub)
 
         # then
         self.assertDictEqual(expected_default_continent, results)
@@ -139,7 +139,7 @@ class FunctionTestCase(unittest.TestCase):
         }
 
         # when
-        results = function.map_query_results(stub)
+        results = dynamicfilter.map_query_results(stub)
 
         # then
         self.assertDictEqual(expected_default_continent, results)
@@ -161,7 +161,7 @@ class FunctionTestCase(unittest.TestCase):
         }}
 
         # when
-        results = function.map_query_results(stub)
+        results = dynamicfilter.map_query_results(stub)
 
         # then
         self.assertEqual(expected_results, results)
@@ -191,7 +191,31 @@ class FunctionTestCase(unittest.TestCase):
         }
 
         # when
-        results = function.map_query_results(stub)
+        results = dynamicfilter.map_query_results(stub)
+
+        # then
+        self.assertDictEqual(expected_default_continent, results)
+
+    def test_given_multiple_hosts_result_map_filters_correctly123(self):
+        # given
+        stub = [
+            DynamicFilterQueryResult('33across', 'AF', 'RU', 'default', 0.05),
+            DynamicFilterQueryResult('33across', 'AS', 'default', 'default', 0.05)
+        ]
+
+        expected_default_continent = {
+            "33across": {
+                "AF": {
+                    "default": 0.05
+                },
+                "AS": {
+                    "default": 0.05
+                }
+            }
+        }
+
+        # when
+        results = dynamicfilter.map_query_results(stub)
 
         # then
         self.assertDictEqual(expected_default_continent, results)
@@ -257,7 +281,7 @@ class FunctionTestCase(unittest.TestCase):
         }
 
         # when
-        results = function.map_query_results(stub)
+        results = dynamicfilter.map_query_results(stub)
 
         # then
         self.assertDictEqual(expected_default_continent, results)
@@ -265,11 +289,11 @@ class FunctionTestCase(unittest.TestCase):
 
 class DynamicFilterQueryResult:
     def __init__(self, bidder, continent, country, host, filter):
-        self.Bidder = bidder
-        self.Continent = continent
-        self.Country = country
-        self.Host = host
-        self.Filter = filter
+        self.bidder = bidder
+        self.continent = continent
+        self.country = country
+        self.host = host
+        self.filter = filter
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+google-cloud-bigquery
+google-cloud-logging
+python-dateutil
+PyGithub

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,276 @@
+import unittest
+
+import function
+
+
+class FunctionTestCase(unittest.TestCase):
+
+    maxDiff = None
+
+    def test_given_empty_result_throw_exception(self):
+        # given
+        stub = []
+
+        # when-then
+        with self.assertRaises(Exception) as e:
+            function.map_query_results(stub)
+
+        self.assertTrue("Failed to map results: empty query result list" in str(e.exception))
+
+    def test_given_country_default_and_host_non_default_result_throw_exception(self):
+        # given
+        stub = [
+            DynamicFilterQueryResult("adform", "AF", "default", "www.testing.com", 1.0),
+        ]
+
+        # when-then
+        with self.assertRaises(Exception) as e:
+            print(function.map_query_results(stub))
+
+        self.assertTrue("Invalid row format: default country and non default host isn't allowed: "
+                        "www.testing.com" in str(e.exception))
+
+    def test_given_none_filter_value_result_throw_exception(self):
+        # given
+        stub = [
+            DynamicFilterQueryResult("adform", "AF", "default", "www.testing.com", None)
+        ]
+
+        # when-then
+        with self.assertRaises(Exception) as e:
+            print(function.map_query_results(stub))
+
+        self.assertTrue("Invalid row format: empty column value is now allowed")
+
+    def test_given_empty_host_value_result_throw_exception(self):
+        # given
+        stub = [
+            DynamicFilterQueryResult("adform", "AF", "default", "", 1.0)
+        ]
+
+        # when-then
+        with self.assertRaises(Exception) as e:
+            print(function.map_query_results(stub))
+
+        self.assertTrue("Invalid row format: empty column value is now allowed")
+
+    def test_given_default_continent_result_map_filters_correctly(self):
+        # given
+        stub = [
+            DynamicFilterQueryResult("adform", "AF", "ZA", "www.aljazeera.com", 1.0),
+            DynamicFilterQueryResult("adform", "AF", "default", "default", 0.2)
+        ]
+
+        expected_default_continent = {
+            "adform": {
+                "AF": {
+                    "default": 0.2,
+                    "ZA": {
+                        "www.aljazeera.com": 1.0
+                    }
+                }
+            }
+        }
+
+        # when
+        results = function.map_query_results(stub)
+
+        # then
+        self.assertDictEqual(expected_default_continent, results)
+
+    def test_given_default_continent_only_result_map_filters_correctly(self):
+        # given
+        stub = [
+            DynamicFilterQueryResult("adform", "AF", "default", "default", 0.2)
+        ]
+
+        expected_default_continent = {
+            "adform": {
+                "AF": {
+                    "default": 0.2
+                }
+            }
+        }
+
+        # when
+        results = function.map_query_results(stub)
+
+        # then
+        self.assertDictEqual(expected_default_continent, results)
+
+    def test_given_default_country_only_result_map_filters_correctly(self):
+        # given
+        stub = [
+            DynamicFilterQueryResult("adform", "AF", "SA", "default", 0.1)
+        ]
+
+        expected_default_continent = {
+            "adform": {
+                "AF": {
+                    "SA": {
+                        "default": 0.1
+                    }
+                }
+            }
+        }
+
+        # when
+        results = function.map_query_results(stub)
+
+        # then
+        self.assertDictEqual(expected_default_continent, results)
+
+    def test_given_default_country_result_map_filters_correctly(self):
+        # given
+        stub = [
+            DynamicFilterQueryResult("adform", "AF", "ZA", "www.aljazeera.com", 1.0),
+            DynamicFilterQueryResult("adform", "AF", "ZA", "default", 0.2)
+        ]
+
+        expected_default_continent = {
+            "adform": {
+                "AF": {
+                    "ZA": {
+                        "default": 0.2,
+                        "www.aljazeera.com": 1.0
+                    }
+                }
+            }
+        }
+
+        # when
+        results = function.map_query_results(stub)
+
+        # then
+        self.assertDictEqual(expected_default_continent, results)
+
+    def test_given_multiple_countries_result_map_filters_correctly(self):
+        # given
+        stub = [
+            DynamicFilterQueryResult("adform", "AF", "LA", "default", 1.0),
+            DynamicFilterQueryResult("adform", "AF", "ZA", "www.aljazeera.com", 1.0),
+            DynamicFilterQueryResult("adform", "AF", "default", "default", 1.0),
+            DynamicFilterQueryResult("adform", "AF", "ZA", "www.another-site.com", 0.5),
+            DynamicFilterQueryResult("adform", "AF", "LA", "www.another-site.com", 0.5),
+            DynamicFilterQueryResult("adform", "AF", "ZA", "default", 0.8)
+        ]
+
+        expected_results = {'adform': {
+            'AF': {'LA': {'default': 1.0, 'www.another-site.com': 0.5},
+                   'ZA': {'www.aljazeera.com': 1.0, 'www.another-site.com': 0.5, 'default': 0.8}, 'default': 1.0}
+        }}
+
+        # when
+        results = function.map_query_results(stub)
+
+        # then
+        self.assertEqual(expected_results, results)
+
+    def test_given_multiple_hosts_result_map_filters_correctly(self):
+        # given
+        stub = [
+            DynamicFilterQueryResult("adform", "AF", "ZA", "default", 1.0),
+            DynamicFilterQueryResult("adform", "AF", "ZA", "www.testing.com", 0.8),
+            DynamicFilterQueryResult("adform", "AF", "SA", "www.another-test.com", 1),
+            DynamicFilterQueryResult("adform", "AF", "SA", "www.aljazeera.com", 0.2)
+        ]
+
+        expected_default_continent = {
+            "adform": {
+                "AF": {
+                    "ZA": {
+                        "default": 1.0,
+                        "www.testing.com": 0.8
+                    },
+                    "SA": {
+                        "www.another-test.com": 1.0,
+                        "www.aljazeera.com": 0.2
+                    }
+                }
+            }
+        }
+
+        # when
+        results = function.map_query_results(stub)
+
+        # then
+        self.assertDictEqual(expected_default_continent, results)
+
+    def test_given_multiple_bidders_result_map_filters_correctly(self):
+        # given
+        stub = [
+            DynamicFilterQueryResult("adform", "AF", "ZA", "default", 1.0),
+            DynamicFilterQueryResult("adform", "AF", "default", "default", 0.2),
+            DynamicFilterQueryResult("adform", "AF", "ZA", "www.testing.com", 0.8),
+            DynamicFilterQueryResult("adform", "AF", "SA", "www.another-test.com", 1),
+            DynamicFilterQueryResult("adform", "SA", "BR", "www.another-test.com", 1),
+            DynamicFilterQueryResult("adform", "SA", "BR", "default", 0.5),
+            DynamicFilterQueryResult("another-bidder", "SA", "BR", "www.testing123.com", 0.2),
+            DynamicFilterQueryResult("another-bidder", "AF", "ZA", "default", 1.0),
+            DynamicFilterQueryResult("another-bidder", "AF", "default", "default", 0.2),
+            DynamicFilterQueryResult("another-bidder", "AF", "ZA", "www.testing.com", 0.8),
+            DynamicFilterQueryResult("another-bidder", "AF", "SA", "www.another-test.com", 1),
+            DynamicFilterQueryResult("another-bidder", "SA", "default", "default", 0.9),
+            DynamicFilterQueryResult("another-bidder", "SA", "BR", "www.another-test.com", 1),
+            DynamicFilterQueryResult("another-bidder", "SA", "BR", "default", 0.5),
+        ]
+
+        expected_default_continent = {
+            "adform": {
+                "AF": {
+                    "default": 0.2,
+                    "ZA": {
+                        "default": 1.0,
+                        "www.testing.com": 0.8
+                    },
+                    "SA": {
+                        "www.another-test.com": 1.0
+                    }
+                },
+                "SA": {
+                    "BR": {
+                        "default": 0.5,
+                        "www.another-test.com": 1.0
+                    }
+                }
+            },
+            "another-bidder": {
+                "AF": {
+                    "default": 0.2,
+                    "ZA": {
+                        "default": 1.0,
+                        "www.testing.com": 0.8
+                    },
+                    "SA": {
+                        "www.another-test.com": 1.0
+                    }
+                },
+                "SA": {
+                    "default": 0.9,
+                    "BR": {
+                        "default": 0.5,
+                        "www.another-test.com": 1.0,
+                        "www.testing123.com": 0.2
+                    }
+                }
+            }
+        }
+
+        # when
+        results = function.map_query_results(stub)
+
+        # then
+        self.assertDictEqual(expected_default_continent, results)
+
+
+class DynamicFilterQueryResult:
+    def __init__(self, bidder, continent, country, host, filter):
+        self.Bidder = bidder
+        self.Continent = continent
+        self.Country = country
+        self.Host = host
+        self.Filter = filter
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**[S2s-1318](https://freestar.atlassian.net/browse/S2S-1318) | Release Version**

## Description, Motivation and Context
This PR aims to update the dynamic filters Cloud Function that produces the JSON configs for PBS. The changes intends to comply with the new [Traffic Shaping query](https://freestar.atlassian.net/wiki/spaces/PROS/pages/80443801636/Dynamic+Filters+for+PBS) and new config [format](https://freestar.atlassian.net/wiki/spaces/PROS/pages/80443801816/Proposed+JSON+Format). Furthermore, this includes a complete refactor of the config mapping and logging code, besides unit tests.

**What are the changes?**
- Update the function query 
- Created a new module and script called `dynamicfilters` to map the query results to the new config format
- Updated all logging configs for the GCP recommendations

## How Has This Been Tested?  Is there anything you weren't able to fully test?
Tested through unit tests and on GCP

## Does this change require updates outside the code, like updating the documentation, adding a feature flag, or adding fields to a DB table? If so, was this done?
No

## Any tickets that this is dependent upon?
No

## Should reviewers manually test your changes?
No

**If yes, how should reviewers manually test?**
No

## Checklist:
[x] Unit tests are all passing on local.

[x] I unit-tested the new functionality.
